### PR TITLE
updated gitlabhq's default mysql database schema filename

### DIFF
--- a/gitlab-install-el6.sh
+++ b/gitlab-install-el6.sh
@@ -244,7 +244,7 @@ else
   service mysqld start
 
   # Copy congiguration
-  cp config/database.yml.example config/database.yml
+  cp config/database.yml.mysql config/database.yml
 
   # Set MySQL root password in configuration file
   sed -i "s/secure password/$MYSQL_ROOT_PW/g" config/database.yml


### PR DESCRIPTION
Gitlab's stable version now uses config/database.yml.mysql or config/database.yml.postgresql as it's default db schemas for importing.
