### PR TITLE
x86_64 branch?

### DIFF
--- a/gitlab-install-el5.sh
+++ b/gitlab-install-el5.sh
@@ -23,7 +23,7 @@ baseurl=http://dl.atrpms.net/el$releasever-$basearch/atrpms/testing
 export GL_INSTALL_BRANCH=stable
 
 # Define the version of ruby the environment that we are installing for
-export RUBY_VERSION=ruby-1.9.2-p290
+export RUBY_VERSION=ruby-1.9.3-p362
 
 # Define the rails environment that we are installing for
 export RAILS_ENV=production

--- a/gitlab-install-el6.sh
+++ b/gitlab-install-el6.sh
@@ -22,7 +22,7 @@ export GL_INSTALL_ROOT=/var/www/gitlabhq
 export GL_INSTALL_BRANCH=stableb
 
 # Define the version of ruby the environment that we are installing for
-export RUBY_VERSION=ruby-1.9.2-p290
+export RUBY_VERSION=ruby-1.9.3-p362
 
 # Define the rails environment that we are installing for
 export RAILS_ENV=production


### PR DESCRIPTION
I was hoping it would be possible for a branch supporting x86_64 architectures, so I changed the EPEL URLs to point to the x86_64 directory instead, and updated the epel-release-... RPM for EL6 also.
