### PR TITLE
Fix el6

### DIFF
--- a/gitlab-install-el6.sh
+++ b/gitlab-install-el6.sh
@@ -34,6 +34,10 @@ die()
 echo "### Check OS (we check if the kernel release contains el6)"
 uname -r | grep "el6" || die 1 "Not RHEL or CentOS 6 (el6)"
 
+# Disable selinux
+setenforce 0
+sed -i "s/SELINUX=enforcing/SELINUX=permissive/g" /etc/sysconfig/selinux
+
 # Install base packages
 yum -y install git
 


### PR DESCRIPTION
This pull request fix some problems i had faced in rhel6. 
First, the version 5-0, does not have scripts/web and scripts/background_jobs, so i changed the default version of gitlab the latest version. 6.5 

Second, Selinux is enabled by default in rhel6 and should be disabled for gitlab to work properly. 

The third and last change, libyaml and libyaml-devel is already installed from epel, so we don't need to install it as rvm pkg. 
